### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+    contents: read
+
 on:
     push:
         branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/eapCJ/node-red-contrib-ws281x/security/code-scanning/1](https://github.com/eapCJ/node-red-contrib-ws281x/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the workflow only checks out the code, sets up Node.js, installs dependencies, and runs tests, it only needs `contents: read` permission. This ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
